### PR TITLE
Better workflow for admin channel

### DIFF
--- a/matrix_appservice_hangouts/appservice.py
+++ b/matrix_appservice_hangouts/appservice.py
@@ -297,19 +297,14 @@ Received Matrix Transaction:
         log.debug("m.room.member")
         content = event['content']
         if content['membership'] == "invite" and content.get('is_direct'):
-            # If we already have an active admin channel with this user, don't
-            # join another.
             user_id = event['user_id']
-            if user_id not in self.admin_channels.keys():
-                resp = await self.matrix_client.join_room(event['room_id'])
-                self.admin_channels[user_id] = event['room_id']
-            # TODO: test this code path.
-            elif user_id not in self.admin_channels.keys() and self.admin_channels[user_id] != event['room_id']:
-                resp = await self.matrix_client.join_room(self.admin_channels[user_id])
-                resp = await self.matrix_client.invite_user(self.admin_channels[user_id], user_id)
-            else:
-                resp = await self.matrix_client.send_message(self.admin_channels[user_id], "Hello")
+            if user_id in self.admin_channels.keys():
+                room_id = self.admin_channels[user_id]
+                await self.matrix_client.leave_room(room_id)
 
+            await self.matrix_client.join_room(event['room_id'])
+            self.admin_channels[user_id] = event['room_id']
+            resp = await self.matrix_client.send_message(self.admin_channels[user_id], "Hello")
             return resp
 
     async def handle_admin_message(self, event):

--- a/matrix_appservice_hangouts/matrix_client.py
+++ b/matrix_appservice_hangouts/matrix_client.py
@@ -136,6 +136,21 @@ class MatrixClient:
                                 params=p)
         return resp
 
+    async def leave_room(self, room_id, user_id=None, access_token=True):
+        room_id = quote(room_id)
+        if access_token:
+            p = self._token_params()
+        else:
+            p = {}
+        if user_id:
+            p.update(self._as_uid(user_id))
+
+
+        resp = await self._send("POST", f"rooms/{room_id}/leave",
+                                api_path=self.room_endpoint,
+                                params=p)
+        return resp
+
     async def create_room(self, alias_name, invitees=None):
         """
         """


### PR DESCRIPTION
If the user try to invite us to a new room, we leave the previous one and accept the invitation.

I had trouble while trying to make the bridge work. It was on a state where it already registered the admin channel but did not join it, so the "hello" message sending was failing. I find this workflow better: the bridge always follows what the user want to do.